### PR TITLE
update compatibility for wr1043v1 (130428 and 140319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It has been tested with:
 * TP-Link TL-WR841N V10 (Firmware 150616)
 * TP-Link TL-WDR3600 v1 (Firmware 130909, 141022, 150302 and 150518)
 * TP-Link TL-WDR4300 v1 (Firmware 141113, 150302 and 150518)
+* TP-Link TL-WR1043ND v1 (Firmware 130428 and 140319)
 * TP-Link TL-WR1043ND v2 (Firmware 140912, 150717 and 150910)
 
 


### PR DESCRIPTION
after https://github.com/digineo/gluon-autoflasher/commit/0277925d1523fb99b03c88e17ba7a35372aa1cb8
TL-WR1043 V1 works, so we can close https://github.com/digineo/gluon-autoflasher/issues/7
* 3.13.13 Build 130428 Rel.58290n -> status: ✓ (works)
* 3.13.15 Build 140319 Rel.41339n -> status: ✓ (works)